### PR TITLE
Allow to override everything using environment variables

### DIFF
--- a/core/nightwatch.conf.js
+++ b/core/nightwatch.conf.js
@@ -1,4 +1,4 @@
-const env = require('./core/tests/Drupal/Nightwatch/env');
+const env = require('./tests/Drupal/Nightwatch/env');
 
 const args = ['--disable-gpu', ...env.CHROME_ARGS];
 if (env.HEADLESS_CHROME) {

--- a/core/nightwatch.conf.js
+++ b/core/nightwatch.conf.js
@@ -1,13 +1,13 @@
-const settings = require('./nightwatch.settings.json');
+const env = require('./core/tests/Drupal/Nightwatch/env');
 
-const args = ['--disable-gpu', ...settings.CHROME_ARGS];
-if (settings.HEADLESS_CHROME) {
+const args = ['--disable-gpu', ...env.CHROME_ARGS];
+if (env.HEADLESS_CHROME) {
   args.push('--headless');
 }
 
 module.exports = {
   src_folders: ['tests/Drupal/Nightwatch/Tests'],
-  output_folder: settings.NIGHTWATCH_OUTPUT,
+  output_folder: env.NIGHTWATCH_OUTPUT,
   custom_commands_path: ['tests/Drupal/Nightwatch/Commands'],
   custom_assertions_path: '',
   page_objects_path: '',
@@ -18,7 +18,7 @@ module.exports = {
   test_settings: {
     default: {
       selenium_port: 9515,
-      selenium_host: settings.NIGHTWATCH_HOSTNAME,
+      selenium_host: env.WEBDRIVER_HOSTNAME,
       default_path_prefix: '',
       desiredCapabilities: {
         browserName: 'chrome',
@@ -31,7 +31,7 @@ module.exports = {
         enabled: true,
         on_failure: true,
         on_error: true,
-        path: `${settings.NIGHTWATCH_OUTPUT}/screenshots`,
+        path: `${env.NIGHTWATCH_OUTPUT}/screenshots`,
       },
     },
   },

--- a/core/nightwatch.settings.json.default
+++ b/core/nightwatch.settings.json.default
@@ -2,7 +2,7 @@
   "BASE_URL": "",
   "DB_URL": "",
   "NIGHTWATCH_OUTPUT": "reports/nightwatch",
-  "NIGHTWATCH_HOSTNAME": "",
+  "WEBDRIVER_HOSTNAME": "",
   "HEADLESS_CHROME": true,
   "CHROME_ARGS": []
 }

--- a/core/tests/Drupal/Nightwatch/env.js
+++ b/core/tests/Drupal/Nightwatch/env.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 
 const env = {};
 
-if (!fs.fileExistsSync('../../../nightwatch.settings.json')) {
+if (!fs.existsSync('nightwatch.settings.json')) {
   throw new Error('You need to setup the nightwatch.settings.json.default to nightwatch.settings.json')
 }
 
@@ -51,5 +51,5 @@ availableSettings.forEach((setting) => {
   }
 });
 
-module.export = env;
+module.exports = env;
 

--- a/core/tests/Drupal/Nightwatch/env.js
+++ b/core/tests/Drupal/Nightwatch/env.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+
+const env = {};
+
+if (!fs.fileExistsSync('../../../nightwatch.settings.json')) {
+  throw new Error('You need to setup the nightwatch.settings.json.default to nightwatch.settings.json')
+}
+
+const settings = require('../../../nightwatch.settings.json');
+const availableSettings = [
+  ['SIMPLETEST_BASE_URL', 'BASE_URL'],
+  ['DB_URL', 'SIMPLETEST_DB'],
+  'NIGHTWATCH_OUTPUT',
+  'WEBDRIVER_HOSTNAME',
+  'HEADLESS_CHROME',
+  'CHROME_ARGS'
+];
+
+availableSettings.forEach((setting) => {
+  // Some settings have aliases. For those we first lookup all env variables and then all settings.
+  if (!Array.isArray(setting)) {
+    setting = [setting];
+  }
+  let envSetting = setting.reduce((agg, settingName) => {
+    if (agg) {
+      return agg;
+    }
+    if (process.env[settingName]) {
+      return process.env[settingName];
+    }
+  }, '');
+  if (!envSetting) {
+    envSetting = setting.reduce((agg, settingName) => {
+      if (agg) {
+        return agg;
+      }
+      if (settings[settingName]) {
+        return settings[settingName];
+      }
+    });
+  }
+
+  if (envSetting) {
+    setting.forEach((settingName) => {
+      env[setting] = process.env[settingName] = envSetting;
+    });
+  // Note: The simpletest DB is optional, when there is a local drupal
+  // installation.
+  } else if (setting.findIndex('DB_URL') === -1) {
+    throw new Error(`Missing ${settings.join(', ')} configuration item or environment variable.`);
+  }
+});
+
+module.export = env;
+

--- a/core/tests/Drupal/Nightwatch/globals.js
+++ b/core/tests/Drupal/Nightwatch/globals.js
@@ -1,28 +1,15 @@
 const chromedriver = require('chromedriver');
-const settings = require('../../../nightwatch.settings.json');
+const env = require('./env');
 
 module.exports = {
   before: (done) => {
-    // Setting up 
-    const baseUrl = process.env.SIMPLETEST_BASE_URL || settings.BASE_URL || process.env.BASE_URL;
-
-    if (baseUrl === undefined) {
-      throw new Error('Missing a BASE_URL or SIMPLETEST_BASE_URL configuration item.');
-    }
-
-    process.env.BASE_URL = process.env.SIMPLETEST_BASE_URL = baseUrl;
-
-    // Note: The simpletest DB is optional, when there is a local drupal
-    // installation.
-    process.env.SIMPLETEST_DB = process.env.SIMPLETEST_DB || settings.DB_URL;
-
-    if (process.env.NODE_ENV !== 'testbot') {
+    if (env.NODE_ENV !== 'testbot') {
       chromedriver.start();
     }
     done();
   },
   after: (done) => {
-    if (process.env.NODE_ENV !== 'testbot') {
+    if (env.NODE_ENV !== 'testbot') {
       chromedriver.stop();
     }
     done();


### PR DESCRIPTION
* Right now settings.json values win over environment variables
* This makes it hard for testbot to change the configuration bits.
* As alternative every setting is now pulled from the environment first.

I would need to do some more testing